### PR TITLE
丫 (๑°Miku°๑)丫 .ᐟ.ᐟ »-v0.1.2→

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 丫 (๑°Miku°๑)丫 .ᐟ.ᐟ »-v0.1.1→
+# 丫 (๑°Miku°๑)丫 .ᐟ.ᐟ »-v0.1.2→
 ╰ `Miku` é uma biblioteca para criação de salas de voz no Discord, ideal para quando os duos desejam se comunicar após adquirir um serviço no **[Duozada](https://app.duozada.com/)**. <br>
 ╰ **[Duozada](https://app.duozada.com/)** é um `marketplace` para venda de serviços para jogos online. 
 
@@ -16,7 +16,7 @@ const miku = new Miku({
 });
 
 try {
-    const channel = await miku.create.voiceChannel({
+    const channel = miku.voiceChannel.create({
     name: '<CHANNEL_NAME>',
     parent_id: '<CATEGORY_ID>',
     usersId: ['123', '321']

--- a/miku/Miku.ts
+++ b/miku/Miku.ts
@@ -1,7 +1,7 @@
 import type { ChannelResponse, Options, VoiceChannelOptions, VoiceChannelResponse } from "@miku/types";
 import VoiceChannel from "./VoiceChannel";
 
-interface VoiceCh {
+interface VoiceMethods {
     create(channel: VoiceChannelOptions): Promise<VoiceChannelResponse>
     delete(id: string): Promise<ChannelResponse>
 }
@@ -14,7 +14,7 @@ export default class Miku {
         Miku.guild_id= opts.guild_id;
     }
 
-    public get voiceChannel(): VoiceCh {
+    public get voiceChannel(): VoiceMethods {
         return new VoiceChannel(this.opts)
     }
 

--- a/miku/error/ValidationError.ts
+++ b/miku/error/ValidationError.ts
@@ -4,7 +4,7 @@ export default class ValidationError {
     public constructor(private readonly data: any) {
         switch (true) {
             case this.data?.code == 0:
-                const [code, message] = this.data.message.split(':');
+                const [code = 500, message = 'unknown'] = this.data.message.split(':');
                 throw new MikuError({ code: Number(code), type: 'Miku', message: message?.trim() })
             case 'errors' in this.data: {
                 throw new MikuError({ code: data.code, type: 'Miku', message: data.message, error_details: data.errors })

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "miku",
   "description": "Miku, will create a voice channel on Discord for you.",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "devDependencies": {
     "@types/bun": "latest"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,8 +27,7 @@
       "@miku": ["./miku/Miku"],
       "@miku/enum": ["./miku/enum/Channel"],
       "@miku/types": ["./miku/types/Miku"],
-      "@miku/error/*": ["./miku/error/*"],
-      "@miku/cache": ["./miku/Cache"]
+      "@miku/error/*": ["./miku/error/*"]
     }
   }
 }


### PR DESCRIPTION
interface **VoiceCH** foi renomeada para » **[VoiceMethods](https://github.com/projetos-aleatorios/miku/blob/929b9e387d4b851e4b4e286c6df5bfc25aceced8/miku/Miku.ts#L4)**
Agora em **[ValidationError](https://github.com/projetos-aleatorios/miku/blob/929b9e387d4b851e4b4e286c6df5bfc25aceced8/miku/error/ValidationError.ts#L7)** retorna um erro padrão quando o array retornar `undefined`. 
o caminho **@miku/cache** foi removido.